### PR TITLE
CORE-7718: don't discard messages when iRODS is down

### DIFF
--- a/src/dewey/curation.clj
+++ b/src/dewey/curation.clj
@@ -342,13 +342,11 @@
             (log/info "Attempted to index a non-existent iRODS entity. Most likely it was deleted after"
                       "this index message was created."))
           (catch JargonException e
-            (if (instance? IOException (.getCause e))
-              (do
-                (log/warn "Failed to connect to iRODs. Could not process route" routing-key
-                          "with message" msg ". Backing off.")
-                (irods-backoff) ; This will retry forever
-                (throw e))
-              (throw e))))
+            (when (instance? IOException (.getCause e))
+              (log/warn "Failed to connect to iRODs. Could not process route" routing-key
+                        "with message" msg ". Backing off.")
+              (irods-backoff)) ; This will retry forever
+            (throw e)))
         (log/warn (str "unknown routing key" routing-key "received with message" msg)))
       (let [consumetime (milliseconds-since consume-start)]
         (tc/with-logging-context {:amqp-total-time consumetime :dewey-consume-time @innertime}


### PR DESCRIPTION
I finally got annoyed enough that this was hanging around that I've decided to try to fix it.
 
* Exponential backoff starting at 1s and doubling up to 1 hour (max total sleep time works out to 2:08:15)
* Exit dewey entirely after the 1h sleep fails
* Always requeue messages which are iRODS connection failures, to ensure they won't get discarded