### PR TITLE
Add ability to use basic auth with Elasticsearch

### DIFF
--- a/dewey.properties.tmpl
+++ b/dewey.properties.tmpl
@@ -9,6 +9,8 @@ dewey.environment-name          = {{ env "DE_ENV" }}
 {{ with $v := (key (printf "%s/amqp/uri" $base)) }}dewey.events.amqp.uri = {{ $v }}{{ end }}
 
 {{ with $v := (key (printf "%s/elasticsearch/base" $base)) }}dewey.es.uri = {{ $v }}{{ end }}
+{{ with $v := (key (printf "%s/elasticsearch/username" $base)) }}dewey.es.user = {{ $v }}{{ end }}
+{{ with $v := (key (printf "%s/elasticsearch/password" $base)) }}dewey.es.password = {{ $v }}{{ end }}
 {{ with $v := (key (printf "%s/elasticsearch/data-alias" $base)) }}dewey.es.index = {{ $v }}{{ end }}
 
 {{ with $v := (key (printf "%s/irods/host" $base)) }}dewey.irods.host = {{ $v }}{{ end }}

--- a/src/dewey/config.clj
+++ b/src/dewey/config.clj
@@ -72,6 +72,16 @@
   [props config-valid configs]
   "dewey.es.uri" "http://elasticsearch:9200")
 
+(cc/defprop-optstr es-user
+  "The username for the Elasticsearch server"
+  [props config-valid configs]
+  "dewey.es.user" nil)
+
+(cc/defprop-optstr es-password
+  "The password for the Elasticsearch server"
+  [props config-valid configs]
+  "dewey.es.password" nil)
+
 (cc/defprop-optstr es-index
   "The Elasticsearch index"
   [props config-valid configs]

--- a/src/dewey/core.clj
+++ b/src/dewey/core.clj
@@ -22,8 +22,11 @@
   "Establishes a connection to elasticsearch"
   []
   (let [url  (URL. (cfg/es-uri))
+        http-opts (if (or (empty? (cfg/es-user)) (empty? (cfg/es-password)))
+                    {}
+                    {:basic-auth [(cfg/es-user) (cfg/es-password)]})
         conn (try
-               (es/connect(str url))
+               (es/connect (str url) http-opts)
                (catch Exception e
                  (log/debug e)
                  nil))]


### PR DESCRIPTION
Intended behavior is to only use the basic auth when the configuration supplied Elasticsearch username and password are non-empty.