### PR TITLE
Remove an extra index-data-object which appears to be unnecessary

### DIFF
--- a/src/dewey/curation.clj
+++ b/src/dewey/curation.clj
@@ -275,8 +275,7 @@
   (let [update (fn [_ obj]
                  (indexing/update-data-object es obj (entity/size obj) (entity/media-type obj)))
         apply  (fn [obj]
-                 (update-or-index-data-object es obj update)
-                 (indexing/index-data-object es obj))
+                 (update-or-index-data-object es obj update))
         id     (extract-entity-id msg)]
     (apply-or-remove irods es :data-object id apply)))
 


### PR DESCRIPTION
in the data-object.sys-metadata.mod handler.

I don't really see why this is there. `update-or-index` will already do an index if the file doesn't exist, and if it does already there'd be no reason to do the initial update if we're going to reindex afterwards anyway. It appears that in the commit where this changed (e1586a9951dc741adcf70316fa37e09ee668f4a6) it was previously the second case of an `if` around `entity-indexed?`, i.e. it looks like it wasn't deleted as part of the switch to using `update-or-index-data-object`. So I think it can be removed, and it'll speed up processing of these messages a pretty good amount I think.