### PR TITLE
Set up dewey to use a lazy context-map and no-op data-object.metadata.add when the entity is not indexed

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [compojure "1.1.8"]
                  [ring "1.4.0"]
                  [slingshot "0.10.3"]
-                 [org.cyverse/clj-jargon "2.8.3"
+                 [org.cyverse/clj-jargon "2.8.9"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
                  [org.cyverse/clojure-commons "2.8.0"]

--- a/src/dewey/curation.clj
+++ b/src/dewey/curation.clj
@@ -60,10 +60,10 @@
     (when (or (= type :data-object) (indexable? entity)) (op entity))
     (indexing/remove-entity es entity-type entity-id)))
 
-(defn- apply-or-remove-or-noop
+(defn- apply-if-indexed
   [irods es entity-type entity-id op]
   (when (indexing/entity-indexed? es entity-type entity-id)
-    (apply-or-remove irods es entity-type entity-id op)))
+    (op)))
 
 ; This function is recursive and could blow the stack if a collection tree is deep, like 500 or more
 ; levels deep.  This is unlikely in iRODS due to the 2700 character path length restriction.
@@ -200,7 +200,7 @@
   [irods es msg]
   (let [reindex (partial reindex-data-obj-metadata es)
         id      (extract-entity-id msg)]
-    (apply-or-remove-or-noop irods es :data-object id reindex)))
+    (apply-if-indexed irods es :data-object id #(apply-or-remove irods es :data-object id reindex))))
 
 
 (defn- reinidex-obj-dest-metadata-handler


### PR DESCRIPTION
n.b. this will need amendment when https://github.com/cyverse-de/clj-jargon/pull/7 is merged and released -- at present this code will not work, but before merging it will be updated to use the newer version of clj-jargon needed

This will make it so that dewey contacts only elasticsearch in a common case: a data object has been added along with metadata, but the metadata message is being processed before the data object add  message itself. It's not necessary for the message to do anything in this case, because the add message will index the metadata anyway. If instead, the data object has been removed, this will leave it be, but once again other messages handle that case.

This can probably be generalized to more operations within dewey -- all metadata and ACL operations can probably rely on their parent objects' respective add and remove operations rather than doing cleanup themselves. For now I'd like to just do it for this and see how things look, in the interest of caution, but if this approach seems to be good we can extend it.